### PR TITLE
Update test-ridge_regression.R

### DIFF
--- a/tests/testthat/test-ridge_regression.R
+++ b/tests/testthat/test-ridge_regression.R
@@ -52,7 +52,7 @@ test_that("find_best_lambda returns proper data frame", {
     dplyr::select(mpg, hp, cyl) %>%
     dplyr::slice(-rand)
 
-  my_result <- find_best_lambda(train_dat, test_dat, mpg, lambda = lambdas)
+  my_result <- find_best_lambda(train_dat, test_dat, 'mpg', lambda = lambdas)
 
   expect_equal(names(my_result), c("lambda", "error"))
   expect_equal(my_result$lambda, lambdas)


### PR DESCRIPTION
Fixes the following error:

test-ridge_regression.R:55: error: find_best_lambda returns proper data frame
object 'mpg' not found